### PR TITLE
Add conan and .lua files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,7 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 *.suo
+*.vcxproj
 *.vcxproj.filters
 *.npp
 CMakeFiles/*

--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -5,7 +5,7 @@ class DateConan(ConanFile):
     name = "Date"
     version = "3.01"
     url = "https://github.com/Esri/date/tree/runtimecore"
-    license = "https://github.com/Esri/date/blob/runtimecore/LICENSE.txt
+    license = "https://github.com/Esri/date/blob/runtimecore/LICENSE.txt"
     description = "Howard Hinnant's TZDB parser."
 
     # RTC specific triple

--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -1,0 +1,23 @@
+from conans import ConanFile
+
+
+class DateConan(ConanFile):
+    name = "Date"
+    version = "3.01"
+    url = "https://github.com/Esri/date/tree/runtimecore"
+    license = "https://github.com/Esri/date/blob/runtimecore/LICENSE.txt
+    description = "Howard Hinnant's TZDB parser."
+
+    # RTC specific triple
+    settings = "platform_architecture_target"
+
+    def package(self):
+        base = self.source_folder + "/"
+        relative = "3rdparty/date/"
+
+        # headers
+        self.copy("*.h*", src=base + "include", dst=relative + "include")
+
+        # libraries
+        output = "output/" + str(self.settings.platform_architecture_target) + "/staticlib"
+        self.copy("*" + self.name + "*", src=base + "../../" + output, dst=output)

--- a/date.lua
+++ b/date.lua
@@ -1,0 +1,37 @@
+project "date"
+
+dofile(_BUILD_DIR .. "/static_library.lua")
+
+configuration { "*" }
+
+uuid "422C8CCD-5D01-4D78-B0D9-2041681C4EE8"
+defines {
+}
+includedirs {
+  "include",
+}
+files {
+  "src/**.cpp",
+}
+
+if (_PLATFORM_ANDROID) then
+end
+
+if (_PLATFORM_COCOA) then
+end
+
+if (_PLATFORM_IOS) then
+end
+
+if (_PLATFORM_LINUX) then
+end
+
+if (_PLATFORM_MACOS) then
+end
+
+if (_PLATFORM_WINDOWS) then
+end
+
+if (_PLATFORM_WINUWP) then
+
+end

--- a/date.lua
+++ b/date.lua
@@ -5,11 +5,11 @@ dofile(_BUILD_DIR .. "/static_library.lua")
 configuration { "*" }
 
 uuid "422C8CCD-5D01-4D78-B0D9-2041681C4EE8"
-defines {
-}
+
 includedirs {
   "include",
 }
+
 files {
   "src/**.cpp",
 }
@@ -33,5 +33,4 @@ if (_PLATFORM_WINDOWS) then
 end
 
 if (_PLATFORM_WINUWP) then
-
 end


### PR DESCRIPTION
Adds the essentials to build the date library into RTC, builds successfully locally through the date_time RTC project.

~~Running a vtest: https://runtime-rtc.esri.com/me/my-views/view/all/job/vtest/job/3rdparty-interface/296/~~ Of course, date wasn't built because I've not updated the third party architecture files!