### PR TITLE
expr: 1058 rename date to lowercase

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -2,7 +2,7 @@ from conans import ConanFile
 
 
 class DateConan(ConanFile):
-    name = "Date"
+    name = "date"
     version = "3.01"
     url = "https://github.com/Esri/date/tree/runtimecore"
     license = "https://github.com/Esri/date/blob/runtimecore/LICENSE.txt"


### PR DESCRIPTION
(Loosly) Issue: https://devtopia.esri.com/runtime/arcade/issues/1058

Date should be lowercase to match other RTC libraries. 

Irritatingly githubs own edit tool and even Nano would modify the final line of this file.