### PR TITLE
Rob10470/expr1264 C++20ify date

### DIFF
--- a/include/date/ptz.h
+++ b/include/date/ptz.h
@@ -593,7 +593,7 @@ time_zone::name() const
     auto print_offset = [](seconds off)
         {
             std::string nm;
-            hh_mm_ss<seconds> offset{-off};
+            date::hh_mm_ss<seconds> offset{-off};
             if (offset.is_negative())
                 nm += '-';
             nm += std::to_string(offset.hours().count());


### PR DESCRIPTION
Fully qualify hh_mm_ss to resolve the error when compiling Date via C++20 via MSVC.