### PR TITLE
date: Add ios.mm to support current_zone on iOS

### DIFF
--- a/date.lua
+++ b/date.lua
@@ -23,6 +23,9 @@ if (_PLATFORM_COCOA) then
 end
 
 if (_PLATFORM_IOS) then
+  files {
+    "src/ios.mm",
+  }
 end
 
 if (_PLATFORM_LINUX) then


### PR DESCRIPTION
Adds the `ios.mm` file in for iOS builds. This is utilized by the date-tz library to allow getting the current timezone on iOS. This is needed to support the refactoring of our date time implementation to utilize more functionality from this library.

https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/822/downstreambuildview/