### PR TITLE
expr: 1384 remove unsafe boolean checks

### DIFF
--- a/include/date/tz_private.h
+++ b/include/date/tz_private.h
@@ -289,8 +289,8 @@ struct transition
     std::ostream&
     operator<<(std::ostream& os, const transition& t)
     {
-        using date::operator<<;
-        os << t.timepoint << "Z ";
+        using date::operator<<; 
+        date::operator<<(os, t.timepoint) << "Z ";
         if (t.info->offset >= std::chrono::seconds{0})
             os << '+';
         os << make_time(t.info->offset);

--- a/include/date/tz_private.h
+++ b/include/date/tz_private.h
@@ -294,7 +294,7 @@ struct transition
         if (t.info->offset >= std::chrono::seconds{0})
             os << '+';
         os << make_time(t.info->offset);
-        if (t.info->is_dst > 0)
+        if (t.info->is_dst)
             os << " daylight ";
         else
             os << " standard ";

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2635,7 +2635,7 @@ std::ostream&
 operator<<(std::ostream& os, const leap_second& x)
 {
     using namespace date;
-    return os << x.date_ << "  +";
+    return date::operator<<(os, x.date_) << "  +";
 }
 
 #if USE_OS_TZDB

--- a/src/tz.cpp
+++ b/src/tz.cpp
@@ -2030,7 +2030,7 @@ time_zone::load_data(std::istream& inf,
         transitions_.emplace(transitions_.begin(), min_seconds);
         auto tf = std::find_if(ttinfos_.begin(), ttinfos_.end(),
                                [](const expanded_ttinfo& ti)
-                                   {return ti.is_dst == 0;});
+                                   {return !ti.is_dst;});
         if (tf == ttinfos_.end())
             tf = ttinfos_.begin();
         transitions_[i].info = &*tf;
@@ -2220,7 +2220,7 @@ operator<<(std::ostream& os, const time_zone& z)
     if (t.info->offset >= seconds{0})
         os << '+';
     os << make_time(t.info->offset);
-    if (t.info->is_dst > 0)
+    if (t.info->is_dst)
         os << " daylight ";
     else
         os << " standard ";


### PR DESCRIPTION
https://devtopia.esri.com/runtime/arcade/issues/1384
ref: https://devtopia.esri.com/runtime/runtimecore-code-council/issues/156

HH upstream does not appear to have fixed these checks. 

VS compiled with std:C++20 after these checks were fixed. Change on line 2033 is actually unecessary for the VS build but was last suspect usage of that boolean.

~~Do we have a workflow we use for C++20 vtests or should I pull this into WSL and run via that build path?~~

Found the relevant comment in the code council issue, my bad!