### PR TITLE
rob10470/expr_add_TZDB_transition_dump_utility

### DIFF
--- a/embedded_data/tzdb_HH_file_dump.cpp
+++ b/embedded_data/tzdb_HH_file_dump.cpp
@@ -1,0 +1,98 @@
+#define USE_OS_TZDB 0
+#define _WIN32 1
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <algorithm>
+#include <format>
+#include "tz.h"
+
+constexpr date::sys_seconds start_tp = date::sys_days(date::year{ 1800 } / date::January / date::day{ 1 });
+constexpr date::sys_seconds end_tp = date::sys_days(date::year{ 2039 } / date::January / date::day{ 1 });
+
+void write_zone(
+	std::ofstream& output,
+	const std::string& output_name,
+	const date::time_zone& zone,
+	bool is_first_zone)
+{
+	std::cout << "Writing zone: " << output_name << std::endl;
+
+	if (!is_first_zone)
+	{
+		output << "," << std::endl;
+	}
+
+	output << std::format(R"(  {{
+	"tzName":"{}",
+	"transitions":[
+)", output_name);
+
+	bool is_first_transition = true;
+	auto cursor = start_tp;
+
+	while (cursor < end_tp)
+	{
+		const auto info = zone.get_info(cursor);
+		if (start_tp < info.end)
+		{
+			if (!is_first_transition)
+			{
+				output << "," << std::endl;
+			}
+			is_first_transition = false;
+
+			output << std::format(
+				R"(      [
+		"{}",
+		{},
+		{},
+		{},
+		{}
+	  ])",
+				info.abbrev,
+				info.begin.time_since_epoch().count(),
+				info.end.time_since_epoch().count(),
+				info.offset.count(),
+				info.save.count());
+		}
+		cursor = info.end;
+	}
+
+	output << std::endl << "]" << std::endl << "}";
+}
+
+int main(int argc, char* argv[])
+{
+	if (argc != 2)
+	{
+		std::cerr << "Usage: tzdb_HH_file_dump <tzdb_install_path>" << std::endl;
+		return 1;
+	}
+
+	date::set_install(argv[1]);
+	const auto& tzdb = date::reload_tzdb();
+
+	std::ofstream output("tzdb_transitions_dump.json", std::ios::binary | std::ios::trunc);
+	output << "[" << std::endl;
+
+	bool is_first_zone = true;
+
+	for (const auto& zone : tzdb.zones)
+	{
+		write_zone(output, zone.name(), zone, is_first_zone);
+		is_first_zone = false;
+	}
+
+	for (const auto& link : tzdb.links)
+	{
+		const auto* target_zone = tzdb.locate_zone(link.target());
+		std::cout << std::format(R"(Writing link: {} -> {})", link.name(), link.target()) << std::endl;
+		write_zone(output, link.name(), *target_zone, false);
+	}
+
+	output << std::endl << "]" << std::endl;
+
+	std::cout << std::format("Wrote tzdb_transitions_dump.json for {} entries (zones + links).", tzdb.zones.size() + tzdb.links.size());
+	return 0;
+}


### PR DESCRIPTION
### NB: LOW PRIORITY, can be ignored till after release.

### Changes
Add a C++ utility to generate JSON dumps of the TZDB between 1800 and 2038 to catch all explicit transitions. This supports a pre-existing test that checks our modified version of HH and compiled TZDB produces the same result as the original versions. This test is required to be updated as part of the data update so its utility belongs here. 

Code is quick and ~a little bit~ hacky. Will clean up if desired but I felt it better having it on source control (even in this branch) rather than alone on my machine.

### Instructions to regenerate data file (Unchanged):
Check if we need to update the [IANA TZDB](https://www.iana.org/time-zones). Some updates are relatively minor and its possible Pro and RTC won't want to undergo the update process. If we don't, finish.
Pull the approriate IANA TZDB and code into a Linux Distro and compile the Zic Compiler per its instructions. I recommend use of Linux over Windows purely because I found it personally easier. Some Linux Distro's may ship with Zic. Make Zic worked for me.
Copy the deprecated SystemV folder stored under the embedded data folder into the IANA TZDB
Run ZIC on the following files: antartica, africa, asia, australasia, etcetera, europe, northamerica, southamerica, systemv. Store in a location now called CompiledTZDB or some such. Be careful, not specifying a location might make Zic update your Linux Distro's TZDB.
Do not compile Backwards or Backzone, linking is resolved via the embedding script rather than ZIC.
  For Example `./zic -d ~/tzdb/2023c/output/ ~/tzdb/2023c/tzdb-2023c/antarctica ~/tzdb/2023c/tzdb-2023c/africa ~/tzdb/2023c/tzdb-2023c/asia ~/tzdb/2023c/tzdb-2023c/australasia ~/tzdb/2023c/tzdb-2023c/etcetera ~/tzdb/2023c/tzdb-2023c/europe ~/tzdb/2023c/tzdb-2023c/northamerica ~/tzdb/2023c/tzdb-2023c/southamerica ~/tzdb/2023c/tzdb-2023c/systemv `
This will have generated a large number of tzif files in the output location. To see the TZIF format: https://datatracker.ietf.org/doc/html/rfc8536#section-3.3.1
Copy the `leapseconds` and `backwards` file from the uncompiled TZDB to the compiled tzdb.
Copy [windowsZones.xml](https://github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml) into the compiled TZDB.
Run `embedded_data/EmbedData.py PathToCompiledTZDB` and copy the results into the src folder of date.
If script complains of unicode characters you may have tried to compile the TZDB including the .c code files and gotten some corrupted zone files in the TZDB. Delete them and try again.

### New instructions to update test data:
Copy `tzdb_HH_file_dump.cpp` into an unmodified HH implementation and compile it with the HH source files.
If you are not running on windows you will need to update the `#define _WIN32 1` to instead refer to your platform.
Run the resulting executable providing it the directory of an uncompiled TZDB. `./tzdb_HH_file_dump <PathToUncompiledTZDB>`
Wait for it to output a JSON representation of the TZDB in the same folder as the executable named `tzdb_transitions_dump.json` The script will report each file to the console as it writes it to file. Some SystemV timezones may take several minutes to output.
Run the RTC `TimeZoneTest::ValidateTzdbUtcTransitions` test in `date_time_tests::time_zone_test.cpp` pointing at the new json file. This ensures our compilation and loading methods have not altered the data or observable behaviour.
If any failures occur you will need to investigate the TZIF, TZDB, and Json files to determine which are valid. 